### PR TITLE
[bugfix] after cloning librato-statsd dependencies have to be installed

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,6 +14,11 @@ execute "checkout_statsd" do
   cwd "/usr/share"
 end
 
+execute "install dependencies" do
+  command "sudo npm install -d"
+  cwd "/usr/share/statsd"
+end
+
 directory "/etc/statsd" do
   action :create
 end


### PR DESCRIPTION
Hi,

I just fixed a bug that statsd was throwing an error because underscorejs wasn't installed. So i just added in npm install -d after cloning the repo.

Love,
