### PR TITLE
Fix version bump

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default[:statsd][:repo] = "git://github.com/etsy/statsd.git"
 default[:statsd][:revision] = "master"
-default[:statsd][:version] = "0.7.0"
+default[:statsd][:version] = "v0.7.0"
 
 default[:statsd][:log_file] = "/var/log/statsd.log"
 


### PR DESCRIPTION
Etsy uses "vX.Y.Z" rather than "X.Y.Z" when tagging releases.
Otherwise git gives an error: Unable to parse SHA reference for '0.7.0' in repository 'git://github.com/etsy/statsd.git'. Verify your (case-sensitive) repository URL and revision.
