### PR TITLE
moved extra_config merge to prevent overwrites

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "mike@librato.com"
 license          "Apache 2.0"
 description      "Installs/Configures statsd"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.2"
+version          "0.2.3"
 name             "statsd"
 
 depends "build-essential"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -69,14 +69,15 @@ template "/etc/statsd/config.js" do
     :port => node[:statsd][:port],
     :deleteIdleStats => node[:statsd][:delete_idle_stats],
     :backends => backends
-
-  }.merge(node[:statsd][:extra_config])
+  }
 
   if node[:statsd][:graphite_enabled]
     config_hash[:graphite] = { :legacyNamespace => node[:statsd][:legacyNamespace] }
     config_hash[:graphitePort] = node[:statsd][:graphite_port]
     config_hash[:graphiteHost] = node[:statsd][:graphite_host]
   end
+
+  config_hash = config_hash.merge(node[:statsd][:extra_config])
 
   variables(:config_hash => config_hash)
 


### PR DESCRIPTION
An issue was introduced in https://github.com/librato/statsd-cookbook/pull/20:

if graphite is enabled, whatever the extra 'graphite' config is set, it's being overwritten by line 76.
`config_hash[:graphite] = { :legacyNamespace => node[:statsd][:legacyNamespace] }`

This change moves the merge to after all config_hash mutations are done, giving extra_config parameter full control back again.
