### PR TITLE
Allows for extra configuration with the 'graphite' key.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'mike@librato.com'
 license          'Apache 2.0'
 description      'Installs/Configures statsd'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.2'
+version          '0.3.3'
 
 depends 'build-essential'
 depends 'git'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'chef/mixin/deep_merge'
 
 include_recipe 'nodejs'
 include_recipe 'git'
@@ -98,12 +99,12 @@ template "#{node['statsd']['config_dir']}/config.js" do
   }
 
   if node['statsd']['graphite_enabled']
-    config_hash[:graphite] = { legacyNamespace: node['statsd']['legacyNamespace'] }
-    config_hash[:graphitePort] = node['statsd']['graphite_port']
-    config_hash[:graphiteHost] = node['statsd']['graphite_host']
+    config_hash['graphite'] = { 'legacyNamespace' => node['statsd']['legacyNamespace'] }
+    config_hash['graphitePort'] = node['statsd']['graphite_port']
+    config_hash['graphiteHost'] = node['statsd']['graphite_host']
   end
 
-  config_hash = config_hash.merge(node['statsd']['extra_config'])
+  Chef::Mixin::DeepMerge.deep_merge!(node['statsd']['extra_config'], config_hash)
   variables config_hash: config_hash
   notifies :restart, 'service[statsd]', :delayed
 end


### PR DESCRIPTION
A Chef node considers hash keys as strings, by having symbols and
strings the hash can not merge properly and as a result, adding another
`graphite` key to the `extra_config` results in a hash with two
`graphite` keys.
The result is that there is no way at the moment to add any more values to the `graphite`
key (see https://github.com/etsy/statsd/blob/master/docs/namespacing.md
for more examples)

To go around this problem the first thing to do is to remove symbols
from the `config_hash` hash and turn them into strings.
The second thing is to then do a "deep merge" since a regular merge will
only go down one level in the hash. To accomplish this we take advantage
of the Chef Mixins.

`config_hash` should really be a node attribute to prevent this type of
behavior and let Chef handle the deep merges but for the sake of
backward compatibility it was left as is. However this should be
considered when bumping the cookbook to a major release.

This allows the user to do things like this:

``` ruby
node.default['statsd']['extra_config'] = {
  'graphite' => {
    'globalPrefix' => 'something'
  },
}
```

And the output of the config.js will be

```
  "graphite": {
    "legacyNamespace": false,
    "globalPrefix": "something"
  },

```
