### PR TITLE
handle console backend

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,6 +40,9 @@ default['statsd']['graphite_enabled'] = true
 default['statsd']['graphite_port'] = 2003
 default['statsd']['graphite_host'] = 'localhost'
 
+# Enable console output
+default['statsd']['console_enabled'] = false
+
 default['statsd']['service'] = {
   enable: true,
   start: true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,6 +38,10 @@ if node['statsd']['graphite_enabled']
   backends << './backends/graphite'
 end
 
+if node['statsd']['console_enabled']
+  backends << './backends/console'
+end
+
 node['statsd']['backends'].each do |k, v|
   if v
     name = "#{k}@#{v}"


### PR DESCRIPTION
Hey folks,

Would be great to have a hook in the console backend to get around some nasty stuff I have to do to get it working (the `backends` is not exposed, just the `node['statsd']['backends']` which actually calls `npm`).

Thanks!
