### PR TITLE
only install StatsD dependencies when git updated

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -24,9 +24,11 @@ git node['statsd']['path'] do
   repository node['statsd']['repo']
   revision node['statsd']['version']
   action :sync
+  notifies :run, 'execute[install StatsD dependencies]', :immediately
 end
 
-execute 'install dependencies' do
+execute 'install StatsD dependencies' do
   command 'npm install -d'
   cwd node['statsd']['path']
+  action :nothing
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -9,6 +9,9 @@ describe 'statsd::default' do
   cached(:upstart) do
     chef_run.template('/etc/init/statsd.conf')
   end
+  cached(:git) do
+    chef_run.git(node['statsd']['path'])
+  end
 
   %w(nodejs git).each do |recipe|
     it "includes the #{recipe} recipe" do
@@ -24,8 +27,12 @@ describe 'statsd::default' do
     )
   end
 
-  it 'installs statsd dependencies' do
-    expect(chef_run).to run_execute('npm install -d') \
+  it 'notifies to install statsd dependencies' do
+    expect(git).to notify('execute[install StatsD dependencies]').to(:run).immediately
+  end
+
+  it 'only installs statsd dependencies if git notified' do
+    expect(chef_run).to_not run_execute('npm install -d') \
     .with(cwd: node['statsd']['path'])
   end
 


### PR DESCRIPTION
cc @mheffner 

Currently StatsD (https://i.imgur.com/01x9zFo.png) dependencies are always installed even thought StatsD git is not updated.

This PR should fix it, I also included specs.

Thanks for looking!